### PR TITLE
Forbid creating empty trees

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,12 @@ To create a new Merkle Tree with initial elements, use the `new` method. This in
 use merkle_tree::MerkleTree;
 
 fn main() {
+    // Create a new Merkle Tree with initial elements
     let elements = vec!["a", "b", "c", "d"];
-    let tree = MerkleTree::new(elements);
+    let tree = MerkleTree::new(elements).unwrap();
 
-    println!("Root hash: {:?}", tree.root.unwrap());
+    // Print the root hash
+    println!("Root hash: {:?}", tree.root);
 }
 ```
 
@@ -36,9 +38,10 @@ use merkle_tree::MerkleTree;
 
 fn main() {
     let elements = vec!["a", "b", "c", "d"];
-    let tree = MerkleTree::new(elements);
+    let tree = MerkleTree::new(elements).unwrap();
 
-    let proof = tree.generate_proof("a");
+    // Generate a proof for an element
+    let proof = tree.generate_proof("a").unwrap();
     println!("Proof for 'a': {:?}", proof);
 }
 ```
@@ -52,9 +55,10 @@ use merkle_tree::MerkleTree;
 
 fn main() {
     let elements = vec!["a", "b", "c", "d"];
-    let tree = MerkleTree::new(elements);
+    let tree = MerkleTree::new(elements).unwrap();
     let proof = tree.generate_proof("a").unwrap();
 
+    // Verify the proof
     let is_valid = tree.verify("a", proof);
     println!("Is the proof valid? {:?}", is_valid);
 }
@@ -69,11 +73,14 @@ use merkle_tree::MerkleTree;
 
 fn main() {
     let elements = vec!["a", "b", "c", "d"];
-    let mut tree = MerkleTree::new(elements);
-    println!("Root hash: {:?}", tree.root.clone().unwrap());
+    let mut tree = MerkleTree::new(elements).unwrap();
+    println!("Root hash: {:?}", tree.root.clone());
 
+    // Add a new element to the tree
     tree.add_element("e");
-    println!("New root hash: {:?}", tree.root.unwrap());
+
+    // Print the new root hash
+    println!("New root hash: {:?}", tree.root);
 }
 ```
 
@@ -86,10 +93,14 @@ use merkle_tree::MerkleTree;
 
 fn main() {
     let elements = vec!["a", "b", "c", "d"];
-    let mut tree = MerkleTree::new(elements);
+    let mut tree = MerkleTree::new(elements).unwrap();
+
+    // Add a new element to the tree
     tree.add_element("e");
 
+    // Generate and verify a proof for the new element
     let proof = tree.generate_proof("e").unwrap();
     let is_valid = tree.verify("e", proof);
-    println!("Is the proof for 'e' valid? {}", is_valid);
+    println!("Is the proof for 'e' valid? {:?}", is_valid);
 }
+```

--- a/examples/add_element.rs
+++ b/examples/add_element.rs
@@ -2,12 +2,12 @@ use merkle_tree::MerkleTree;
 
 fn main() {
     let elements = vec!["a", "b", "c", "d"];
-    let mut tree = MerkleTree::new(elements);
-    println!("Root hash: {:?}", tree.root.clone().unwrap());
+    let mut tree = MerkleTree::new(elements).unwrap();
+    println!("Root hash: {:?}", tree.root.clone());
 
     // Add a new element to the tree
     tree.add_element("e");
 
     // Print the new root hash
-    println!("New root hash: {:?}", tree.root.unwrap());
+    println!("New root hash: {:?}", tree.root);
 }

--- a/examples/add_generate_verify_proof.rs
+++ b/examples/add_generate_verify_proof.rs
@@ -2,7 +2,7 @@ use merkle_tree::MerkleTree;
 
 fn main() {
     let elements = vec!["a", "b", "c", "d"];
-    let mut tree = MerkleTree::new(elements);
+    let mut tree = MerkleTree::new(elements).unwrap();
 
     // Add a new element to the tree
     tree.add_element("e");

--- a/examples/create_tree.rs
+++ b/examples/create_tree.rs
@@ -3,8 +3,8 @@ use merkle_tree::MerkleTree;
 fn main() {
     // Create a new Merkle Tree with initial elements
     let elements = vec!["a", "b", "c", "d"];
-    let tree = MerkleTree::new(elements);
+    let tree = MerkleTree::new(elements).unwrap();
 
     // Print the root hash
-    println!("Root hash: {:?}", tree.root.unwrap());
+    println!("Root hash: {:?}", tree.root);
 }

--- a/examples/generate_proof.rs
+++ b/examples/generate_proof.rs
@@ -2,7 +2,7 @@ use merkle_tree::MerkleTree;
 
 fn main() {
     let elements = vec!["a", "b", "c", "d"];
-    let tree = MerkleTree::new(elements);
+    let tree = MerkleTree::new(elements).unwrap();
 
     // Generate a proof for an element
     let proof = tree.generate_proof("a").unwrap();

--- a/examples/verify_proof.rs
+++ b/examples/verify_proof.rs
@@ -2,7 +2,7 @@ use merkle_tree::MerkleTree;
 
 fn main() {
     let elements = vec!["a", "b", "c", "d"];
-    let tree = MerkleTree::new(elements);
+    let tree = MerkleTree::new(elements).unwrap();
     let proof = tree.generate_proof("a").unwrap();
 
     // Verify the proof

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,37 +1,20 @@
-use merkle_tree::{MerkleTree, Sibling};
+use merkle_tree::MerkleTree;
 
 #[test]
-fn test_empty_tree() {
+fn test_create_empty_tree() {
     let elements = vec![];
-    let mut tree = MerkleTree::new(elements);
+    let tree = MerkleTree::new(elements);
 
-    assert_eq!(tree.leaves.len(), 0);
-    assert!(tree.root.is_none());
-
-    assert!(tree.generate_proof("a").is_none());
-    assert!(!tree.verify("a", vec![Sibling::Left("test".to_string())]));
-
-    tree.add_element("a");
-    assert_eq!(tree.leaves.len(), 1);
-    assert_eq!(tree.root.clone().unwrap().len(), 64); // SHA256 hash length in hex
-    let proof = tree.generate_proof("a").unwrap();
-    assert!(tree.verify("a", proof));
-
-    tree.add_element("b");
-    assert_eq!(tree.leaves.len(), 2);
-    let proof = tree.generate_proof("b").unwrap();
-    assert!(tree.verify("b", proof.clone()));
-
-    assert!(!tree.verify("c", proof));
+    assert!(tree.is_err())
 }
 
 #[test]
 fn test_tree_with_3_elements() {
     let elements = vec!["a", "b", "c"];
-    let mut tree = MerkleTree::new(elements);
+    let mut tree = MerkleTree::new(elements).unwrap();
 
     assert_eq!(tree.leaves.len(), 3);
-    assert_eq!(tree.root.clone().unwrap().len(), 64);
+    assert_eq!(tree.root.clone().len(), 64); // SHA256 hash length in hex
 
     let mut proof = tree.generate_proof("a").unwrap();
     assert!(tree.verify("a", proof.clone()));
@@ -48,7 +31,7 @@ fn test_tree_with_3_elements() {
 
     tree.add_element("d");
     assert_eq!(tree.leaves.len(), 4);
-    assert_eq!(tree.root.clone().unwrap().len(), 64);
+    assert_eq!(tree.root.clone().len(), 64);
 
     let proof = tree.generate_proof("d").unwrap();
     assert!(tree.verify("d", proof.clone()));
@@ -59,10 +42,10 @@ fn test_tree_with_3_elements() {
 #[test]
 fn test_tree_with_4_elements() {
     let elements = vec!["a", "b", "c", "d"];
-    let mut tree = MerkleTree::new(elements);
+    let mut tree = MerkleTree::new(elements).unwrap();
 
     assert_eq!(tree.leaves.len(), 4);
-    assert_eq!(tree.root.clone().unwrap().len(), 64);
+    assert_eq!(tree.root.clone().len(), 64);
 
     let mut proof = tree.generate_proof("a").unwrap();
     assert!(tree.verify("a", proof.clone()));
@@ -82,7 +65,7 @@ fn test_tree_with_4_elements() {
 
     tree.add_element("e");
     assert_eq!(tree.leaves.len(), 5);
-    assert_eq!(tree.root.clone().unwrap().len(), 64);
+    assert_eq!(tree.root.clone().len(), 64);
 
     let proof = tree.generate_proof("e").unwrap();
     assert!(tree.verify("e", proof.clone()));

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -72,3 +72,65 @@ fn test_tree_with_4_elements() {
 
     assert!(!tree.verify("f", proof));
 }
+
+#[test]
+fn test_tree_with_101_elements() {
+    let elements: Vec<String> = (0..101).map(|i| i.to_string()).collect();
+    let element_refs: Vec<&str> = elements.iter().map(|s| s.as_str()).collect();
+    let mut tree = MerkleTree::new(element_refs).unwrap();
+
+    assert_eq!(tree.leaves.len(), 101);
+    assert_eq!(tree.root.clone().len(), 64);
+
+    let elements_to_test = vec!["0", "50", "100"];
+    for &element in &elements_to_test {
+        let proof = tree.generate_proof(element).unwrap();
+        assert!(tree.verify(element, proof.clone()));
+
+        let mut modified_proof = proof.clone();
+        modified_proof.pop();
+        assert!(!tree.verify(element, modified_proof));
+    }
+
+    assert!(tree.generate_proof("101").is_none());
+
+    tree.add_element("new_element");
+    assert_eq!(tree.leaves.len(), 102);
+    assert_eq!(tree.root.clone().len(), 64);
+
+    let proof = tree.generate_proof("new_element").unwrap();
+    assert!(tree.verify("new_element", proof.clone()));
+
+    assert!(!tree.verify("another_element", proof));
+}
+
+#[test]
+fn test_tree_with_256_elements() {
+    let elements: Vec<String> = (0..256).map(|i| i.to_string()).collect();
+    let element_refs: Vec<&str> = elements.iter().map(|s| s.as_str()).collect();
+    let mut tree = MerkleTree::new(element_refs).unwrap();
+
+    assert_eq!(tree.leaves.len(), 256);
+    assert_eq!(tree.root.clone().len(), 64);
+
+    let elements_to_test = vec!["0", "128", "255"];
+    for &element in &elements_to_test {
+        let proof = tree.generate_proof(element).unwrap();
+        assert!(tree.verify(element, proof.clone()));
+
+        let mut modified_proof = proof.clone();
+        modified_proof.pop();
+        assert!(!tree.verify(element, modified_proof));
+    }
+
+    assert!(tree.generate_proof("256").is_none());
+
+    tree.add_element("new_element");
+    assert_eq!(tree.leaves.len(), 257);
+    assert_eq!(tree.root.clone().len(), 64);
+
+    let proof = tree.generate_proof("new_element").unwrap();
+    assert!(tree.verify("new_element", proof.clone()));
+
+    assert!(!tree.verify("another_element", proof));
+}


### PR DESCRIPTION
- Change `root` type: `Option<String>` -> `String`.
- Modify `new` to return an error if `elements` is empty.
- Update docs, examples and tests.
- Add tests with more elements.